### PR TITLE
Step 3: Upgrade Java Version to 25 - Compile: SUCCESS

### DIFF
--- a/.mvn/wrapper/maven-wrapper.properties
+++ b/.mvn/wrapper/maven-wrapper.properties
@@ -16,4 +16,4 @@
 # under the License.
 wrapperVersion=3.3.2
 distributionType=only-script
-distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.7/apache-maven-3.9.7-bin.zip
+distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.16/apache-maven-3.9.16-bin.zip

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
-FROM maven:3.9-eclipse-temurin-21 AS build
+FROM maven:3.9-eclipse-temurin-25 AS build
 COPY . /usr/src/app
 WORKDIR /usr/src/app
 RUN mvn clean -U package
 
-FROM eclipse-temurin:21-jre-alpine
+FROM eclipse-temurin:25-jre-alpine
 COPY --from=build /usr/src/app/target/html2pdf-1.1.*-SNAPSHOT.jar /app/html2pdf.jar
 WORKDIR /app
 

--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
 		<url/>
 	</scm>
 	<properties>
-		<java.version>21</java.version>
+		<java.version>25</java.version>
 		<openhtml.version>1.1.37</openhtml.version>
 	</properties>
 	<dependencies>


### PR DESCRIPTION
- pom.xml: java.version 21 → 25
- .mvn/wrapper/maven-wrapper.properties: Maven wrapper 3.9.7 → 3.9.16
- Dockerfile: build stage maven:3.9-eclipse-temurin-21 → maven:3.9-eclipse-temurin-25
- Dockerfile: runtime stage eclipse-temurin:21-jre-alpine → eclipse-temurin:25-jre-alpine